### PR TITLE
Tags: Reduce subscriber field return

### DIFF
--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -143,14 +143,7 @@ curl -X POST https://api.convertkit.com/v3/tags/<tag_id>/subscribe\
     "subscribable_id": 1,
     "subscribable_type": "tag",
     "subscriber": {
-      "id": 1,
-      "first_name": "Jon",
-      "email_address": "jonsnow@example.com",
-      "state": "active",
-      "created_at": "2016-02-28T08:07:00Z",
-      "fields": {
-        "last_name": "Snow"
-      }
+      "id": 1
     }
   }
 }


### PR DESCRIPTION
A subscriber being tagged can be done without a secret, this key is
semi-public so it's a security issue that we're returning all the
sensitive fields for a subscriber as the response of a tag request.

We're just removing the fields from the documentation for now since it's
possible for an API to get all those fields from the subscriber endpoint
which requires the secret key.
