### PR TITLE
Subscription: Remove sensitive data from payload with public key

### DIFF
--- a/source/includes/_forms.md
+++ b/source/includes/_forms.md
@@ -92,14 +92,7 @@ curl -X POST https://api.convertkit.com/v3/forms/<form_id>/subscribe\
     "subscribable_id": 1,
     "subscribable_type": "form",
     "subscriber": {
-      "id": 1,
-      "first_name": "Jon",
-      "email_address": "jonsnow@example.com",
-      "state": "active",
-      "created_at": "2016-02-28T08:07:00Z",
-      "fields": {
-        "last_name": "Snow"
-      }
+      "id": 1
     }
   }
 }

--- a/source/includes/_sequences.md
+++ b/source/includes/_sequences.md
@@ -71,14 +71,7 @@ curl -X POST https://api.convertkit.com/v3/sequences/<sequence_id>/subscribe\
     "subscribable_id": 1,
     "subscribable_type": "course",
     "subscriber": {
-      "id": 1,
-      "first_name": "Jon",
-      "email_address": "jonsnow@example.com",
-      "state": "active",
-      "created_at": "2016-02-28T08:07:00Z",
-      "fields": {
-        "last_name": "Snow"
-      }
+      "id": 1
     }
   }
 }


### PR DESCRIPTION
I missed that sequences and forms were also using the same endpoint, so changing the documentation to only include the subscriber id.