### PR TITLE
Update integration information.

### DIFF
--- a/source/includes/_overview.md
+++ b/source/includes/_overview.md
@@ -21,7 +21,7 @@ If you aren't sure how best to structure your integration, just reach out to our
 
 ## Building a larger integration?
 
-If you're working with a company that's building a large integration with ConvertKit, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdiRK0t-LQjBiphLGNy4d6mmG4MXkf7ytrF0b47lvV1bT-_SA/viewform) to get an integration key. We'll work with you to ensure your integration works amazingly for our mutual customers.
+If you're working with a company that's building a large integration with ConvertKit, you will need to use an integration key. This key will help us triaging, troubleshooting and diagnosing potential issues with integrations, ensuring that your integration works perfectly for your customers. Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdiRK0t-LQjBiphLGNy4d6mmG4MXkf7ytrF0b47lvV1bT-_SA/viewform) to request an integration key.
 
 ## API Basics
 

--- a/source/includes/_overview.md
+++ b/source/includes/_overview.md
@@ -21,9 +21,7 @@ If you aren't sure how best to structure your integration, just reach out to our
 
 ## Building a larger integration?
 
-If you're working with a company that's building a large integration with ConvertKit, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdirDoKSD6q018u9PPGLoX5xstF3_LykXzbacuIi9N57warEg/viewform) to get an integration key.  We'll work with you to ensure your integration works amazingly for our mutual customers.
-
-Using an integration key will allow your integration to access specific features of our API, and we'll be able to work with you to set custom rate limiting.
+If you're working with a company that's building a large integration with ConvertKit, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdirDoKSD6q018u9PPGLoX5xstF3_LykXzbacuIi9N57warEg/viewform) to get an integration key. We'll work with you to ensure your integration works amazingly for our mutual customers.
 
 ## API Basics
 

--- a/source/includes/_overview.md
+++ b/source/includes/_overview.md
@@ -21,7 +21,7 @@ If you aren't sure how best to structure your integration, just reach out to our
 
 ## Building a larger integration?
 
-If you're working with a company that's building a large integration with ConvertKit, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdirDoKSD6q018u9PPGLoX5xstF3_LykXzbacuIi9N57warEg/viewform) to get an integration key. We'll work with you to ensure your integration works amazingly for our mutual customers.
+If you're working with a company that's building a large integration with ConvertKit, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdiRK0t-LQjBiphLGNy4d6mmG4MXkf7ytrF0b47lvV1bT-_SA/viewform) to get an integration key. We'll work with you to ensure your integration works amazingly for our mutual customers.
 
 ## API Basics
 

--- a/source/includes/_purchases.md
+++ b/source/includes/_purchases.md
@@ -258,10 +258,10 @@ POST /v3/purchases
 
 ### Required for third party integrations
 
-Are you building an integration? <a href="mailto:engineers@convertkit.com?subject=Purchases integration">Contact us</a> and we will help you get set up.
+Are you building an integration? Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdirDoKSD6q018u9PPGLoX5xstF3_LykXzbacuIi9N57warEg/viewform) and we will help you get set up.
 
 -   `purchase.integration` - The name of your integration (i.e. eBay)
--   `integration_key` - An access token for authenticating integrations.
+-   `integration_key` - A token for tracking integrations.
 
 ### Optional parameters
 

--- a/source/includes/_purchases.md
+++ b/source/includes/_purchases.md
@@ -258,7 +258,7 @@ POST /v3/purchases
 
 ### Required for third party integrations
 
-Are you building an integration? Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdirDoKSD6q018u9PPGLoX5xstF3_LykXzbacuIi9N57warEg/viewform) and we will help you get set up.
+Are you building an integration? Please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLSdiRK0t-LQjBiphLGNy4d6mmG4MXkf7ytrF0b47lvV1bT-_SA/viewform) and we will help you get set up.
 
 -   `purchase.integration` - The name of your integration (i.e. eBay)
 -   `integration_key` - A token for tracking integrations.


### PR DESCRIPTION
`integration_key` is not used for authentication, rate limiting, or access control of any features. Until we can build that it can be used to track integration usage RE: https://convertkit.slack.com/archives/C02G2JWUX/p1599578004303400